### PR TITLE
Prevent multiple event handling

### DIFF
--- a/ToggleColumn.php
+++ b/ToggleColumn.php
@@ -102,6 +102,9 @@ class ToggleColumn extends DataColumn
      */
     public function registerJs()
     {
+        if(Yii::$app->request->isAjax) {
+            return;
+        }
         $js = <<<'JS'
 $(document.body).on("click", "a.toggle-column", function(e) {
     e.preventDefault();


### PR DESCRIPTION
This JS run every time when page update and this is a cause of multiple request sending.
As result, widget works incorrectly.