### PR TITLE
Added fallback for container selection BC break

### DIFF
--- a/ToggleColumn.php
+++ b/ToggleColumn.php
@@ -111,7 +111,7 @@ $(document.body).on("click", "a.toggle-column", function(e) {
     $.post($(this).attr("href"), function(data) {
         var container = $(e.target).closest("[data-pjax-container]");
         if (container.length === 0) {
-            container = $(e.target).closest(".grid-view");
+            container = $(e.target).closest(".grid-view").parent();
         }
         var pjaxId = container.attr("id");
         $.pjax.reload({container:"#" + pjaxId});

--- a/ToggleColumn.php
+++ b/ToggleColumn.php
@@ -109,7 +109,11 @@ class ToggleColumn extends DataColumn
 $(document.body).on("click", "a.toggle-column", function(e) {
     e.preventDefault();
     $.post($(this).attr("href"), function(data) {
-        var pjaxId = $(e.target).closest("[data-pjax-container]").attr("id");
+        var container = $(e.target).closest("[data-pjax-container]");
+        if (container.length === 0) {
+            container = $(e.target).closest(".grid-view");
+        }
+        var pjaxId = container.attr("id");
         $.pjax.reload({container:"#" + pjaxId});
     });
     return false;


### PR DESCRIPTION
Added code to fall back to old behavior when data-pjax-container attributes are not used.